### PR TITLE
Apply UX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Header from './components/Header';
 import BoardSelector from './components/BoardSelector';
 import WheelSelector from './components/WheelSelector';
@@ -8,6 +8,10 @@ import Community from './components/Community';
 
 function App() {
   const [activeSection, setActiveSection] = useState('boards');
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [activeSection]);
 
   const renderSection = () => {
     switch (activeSection) {

--- a/src/components/BoardSelector.tsx
+++ b/src/components/BoardSelector.tsx
@@ -124,7 +124,10 @@ export default function BoardSelector() {
       {/* Résultats */}
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
         {filteredBoards.map((board) => (
-          <div key={board.id} className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300">
+          <div
+            key={board.id}
+            className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 animate-fadeInUp"
+          >
             <div className="aspect-w-16 aspect-h-9 bg-gray-200">
               <img 
                 src={board.image} 

--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -129,7 +129,10 @@ export default function Community() {
 
           {/* Posts */}
           {posts.map((post) => (
-            <div key={post.id} className="bg-white rounded-2xl shadow-lg overflow-hidden">
+            <div
+              key={post.id}
+              className="bg-white rounded-2xl shadow-lg overflow-hidden animate-fadeInUp"
+            >
               <div className="p-6">
                 <div className="flex items-center space-x-3 mb-4">
                   <img 
@@ -190,7 +193,10 @@ export default function Community() {
             
             <div className="space-y-4">
               {events.map((event) => (
-                <div key={event.id} className="border border-gray-200 rounded-lg p-4 hover:border-orange-300 transition-colors duration-200">
+                <div
+                  key={event.id}
+                  className="border border-gray-200 rounded-lg p-4 hover:border-orange-300 transition-colors duration-200 animate-fadeInUp"
+                >
                   <div className="flex items-center space-x-2 mb-2">
                     <span className="bg-orange-100 text-orange-600 text-xs px-2 py-1 rounded-full">
                       {event.type}

--- a/src/components/Guides.tsx
+++ b/src/components/Guides.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BookOpen, Video, Users, Trophy } from 'lucide-react';
+import { BookOpen, Video, Trophy } from 'lucide-react';
 
 interface Guide {
   id: string;
@@ -76,7 +76,10 @@ export default function Guides() {
       {/* Guides principaux */}
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
         {guides.map((guide) => (
-          <div key={guide.id} className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300">
+          <div
+            key={guide.id}
+            className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 animate-fadeInUp"
+          >
             <div className="aspect-w-16 aspect-h-9 bg-gray-200">
               <img 
                 src={guide.image} 
@@ -113,7 +116,10 @@ export default function Guides() {
         <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">💡 Astuces du jour</h3>
         <div className="grid md:grid-cols-3 gap-6">
           {tips.map((tip, index) => (
-            <div key={index} className="bg-white rounded-xl p-6 shadow-sm">
+            <div
+              key={index}
+              className="bg-white rounded-xl p-6 shadow-sm animate-fadeInUp"
+            >
               <div className="flex items-center space-x-2 mb-3">
                 <span className="bg-orange-100 text-orange-500 text-xs font-medium px-3 py-1 rounded-full">
                   {tip.category}
@@ -135,7 +141,7 @@ export default function Guides() {
         </div>
         
         <div className="grid md:grid-cols-2 gap-6">
-          <div className="bg-gray-800 rounded-xl p-6 hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
+          <div className="bg-gray-800 rounded-xl p-6 hover:bg-gray-700 transition-colors duration-200 cursor-pointer animate-fadeInUp">
             <div className="aspect-w-16 aspect-h-9 bg-gray-700 rounded-lg mb-4 flex items-center justify-center">
               <Video className="h-12 w-12 text-gray-500" />
             </div>
@@ -143,7 +149,7 @@ export default function Guides() {
             <p className="text-gray-400 text-sm">Découvre les tricks essentiels pour débuter en street</p>
           </div>
           
-          <div className="bg-gray-800 rounded-xl p-6 hover:bg-gray-700 transition-colors duration-200 cursor-pointer">
+          <div className="bg-gray-800 rounded-xl p-6 hover:bg-gray-700 transition-colors duration-200 cursor-pointer animate-fadeInUp">
             <div className="aspect-w-16 aspect-h-9 bg-gray-700 rounded-lg mb-4 flex items-center justify-center">
               <Video className="h-12 w-12 text-gray-500" />
             </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,9 +36,10 @@ export default function Header({ activeSection, setActiveSection }: HeaderProps)
               <button
                 key={id}
                 onClick={() => setActiveSection(id)}
+                aria-current={activeSection === id ? 'page' : undefined}
                 className={`flex items-center space-x-2 px-3 py-2 rounded-lg transition-all duration-200 ${
                   activeSection === id
-                    ? 'bg-orange-500 text-white'
+                    ? 'bg-orange-500 text-white ring-2 ring-orange-400'
                     : 'text-gray-300 hover:text-white hover:bg-gray-800'
                 }`}
               >
@@ -63,13 +64,14 @@ export default function Header({ activeSection, setActiveSection }: HeaderProps)
             {navItems.map(({ id, label, icon: Icon }) => (
               <button
                 key={id}
+                aria-current={activeSection === id ? 'page' : undefined}
                 onClick={() => {
                   setActiveSection(id);
                   setIsMenuOpen(false);
                 }}
                 className={`flex items-center space-x-3 w-full px-4 py-3 rounded-lg transition-all duration-200 ${
                   activeSection === id
-                    ? 'bg-orange-500 text-white'
+                    ? 'bg-orange-500 text-white ring-2 ring-orange-400'
                     : 'text-gray-300 hover:text-white hover:bg-gray-800'
                 }`}
               >

--- a/src/components/SpotFinder.tsx
+++ b/src/components/SpotFinder.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { MapPin, Star, Clock, Users, Wifi, Car } from 'lucide-react';
+import { MapPin, Star, Clock, Users } from 'lucide-react';
 
 interface Spot {
   id: string;
@@ -132,7 +132,10 @@ export default function SpotFinder() {
       {/* Liste des spots */}
       <div className="space-y-6">
         {filteredSpots.map((spot) => (
-          <div key={spot.id} className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300">
+          <div
+            key={spot.id}
+            className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 animate-fadeInUp"
+          >
             <div className="md:flex">
               <div className="md:w-1/3">
                 <img 

--- a/src/components/WheelSelector.tsx
+++ b/src/components/WheelSelector.tsx
@@ -131,7 +131,10 @@ export default function WheelSelector() {
       {/* Résultats */}
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
         {filteredWheels.map((wheel) => (
-          <div key={wheel.id} className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300">
+          <div
+            key={wheel.id}
+            className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 animate-fadeInUp"
+          >
             <div className={`h-32 ${wheel.color} flex items-center justify-center`}>
               <div className="w-20 h-20 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
                 <div className="w-16 h-16 bg-white rounded-full shadow-lg"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .animate-fadeInUp {
+    @apply animate-fadeInUp;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,17 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        fadeInUp: {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' }
+        }
+      },
+      animation: {
+        fadeInUp: 'fadeInUp 0.5s ease-out'
+      }
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add fade-in animation utilities and config
- animate UI cards across the app
- make the header highlight the active section better
- scroll to top when switching sections
- ignore node and build artifacts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a1f0b81208327a9cfdcb1a8df4920